### PR TITLE
Add Google OAuth2 Instructions

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -12,6 +12,7 @@ Welcome to Multinet
    overview
    quickstart
    multinet
+   oauth2
 
 Indices and tables
 ==================

--- a/oauth2.rst
+++ b/oauth2.rst
@@ -1,0 +1,26 @@
+.. _OAuth2 Credentials:
+
+OAuth2 Credentials
+==================
+
+Multinet uses Google's OAuth2 to verify the identity of users accessing the
+client.
+
+Google OAuth2 Steps
+-------------------------------
+
+To enable OAuth2 on your own project, you'll have to:
+
+1. Either have or `create <https://console.developers.google.com/projectcreate>`_ 
+   a Google Cloud project.
+2. Navigate to the `OAuth consent screen section <https://console.developers.google.com/apis/credentials/consent>`_.
+3. Configure your consent screen, and select "Internal" or "External" based on
+   your application requirements ("External" is usually correct if the
+   instance will be public-facing). Multinet requires the "email", "profile',
+   and 'openid' scopes to run correctly. **NOTE:** Adding a logo means your
+   app will have to go through verification, which can take 6 weeks.
+4. Now go to the `credential section <https://console.developers.google.com/apis/credentials>`_,
+   and select "Create Credentials" > "OAuth2 client ID". 
+5. Set Application type to "Web application" and set a redirect URI. By default,
+   multinet uses <baseurl>/api/user/oauth/google/authorized
+6. Copy the resulting client ID and secret key into your .env file.

--- a/quickstart.rst
+++ b/quickstart.rst
@@ -52,9 +52,10 @@ Build and Run ``multinet-server``
 1. Move into the repository: ``cd multinet-server``.
 2. Copy the ``.env.default`` file: ``cp .env.default .env`` (or symlink it: ``ln
    -s .env.default .env``).
-3. Install the Python dependencies: ``pipenv install``.
-4. Run the server application in dev mode: ``pipenv run serve``.
-5. Point your web browser to http://localhost:5000 to ensure that the server is
+3. Create :ref:`OAuth2 Credentials` and make sure to copy them to your .env file.
+4. Install the Python dependencies: ``pipenv install``.
+5. Run the server application in dev mode: ``pipenv run serve``.
+6. Point your web browser to http://localhost:5000 to ensure that the server is
    working.
 
 Build and Run ``multinet-client``


### PR DESCRIPTION
Closes #16

Adds the required set up instructions for the Google OAuth2 credentials. These are developer docs so including them in the index tree might not be best, or there may be better ways to organize it all. 

@waxlamp, some organizational guidance here would be useful